### PR TITLE
Make Battleaxe level as weapon

### DIFF
--- a/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
+++ b/src/main/java/iguanaman/iguanatweakstconstruct/leveling/handlers/LevelingEventHandler.java
@@ -16,6 +16,7 @@ import net.minecraftforge.client.event.sound.SoundLoadEvent;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.UseHoeEvent;
+import tconstruct.items.tools.Battleaxe;
 import tconstruct.items.tools.Hammer;
 import tconstruct.items.tools.Pickaxe;
 import tconstruct.items.tools.Shortbow;
@@ -42,7 +43,7 @@ public class LevelingEventHandler {
                 {
                     ItemStack stack = player.getCurrentEquippedItem();
                     if (stack != null && stack.hasTagCompound())
-                        if (stack.getItem() instanceof Weapon || stack.getItem() instanceof Shortbow && event.source.damageType.equals("arrow")) {
+                        if (stack.getItem() instanceof Weapon || stack.getItem() instanceof Battleaxe || stack.getItem() instanceof Shortbow && event.source.damageType.equals("arrow")) {
                             long xp = Math.round(event.ammount);
                             if (event.entityLiving instanceof EntityAnimal) xp = Math.round(event.ammount / 4f);
 


### PR DESCRIPTION
The Battleaxe is listed as a weapon but extends HarvestTool rather than Weapon so does not get exp when used as one.
